### PR TITLE
Added dev-tool buttons to the minified_bug.html

### DIFF
--- a/src/lqc/generate/web_page/html_body/create.py
+++ b/src/lqc/generate/web_page/html_body/create.py
@@ -3,7 +3,7 @@ from lqc.model.run_subject import RunSubject
 from lqc.generate.web_page.util import formatWithIndent
 
 current_template = """
-<{tag} style="{style}" id="{element_id}">
+<{tag} style="{style}" {attributes_string} id="{element_id}">
   {children_string}
 </{tag}>
 """
@@ -27,12 +27,21 @@ def create(run_subject: RunSubject):
                     for name, value in styles.get(element["id"], {}).items()
                 ]
             )
+
+            attributes_dict = element.get("attributes", {})
+            allowed_attributes = ["onclick"]
+            attributes_string = " ".join(
+                f"{name}='{value}'"
+                for name, value in attributes_dict.items() if name in allowed_attributes
+            )
+
             element_id = element["id"]
             children_string = reduce_children(element["children"])
             return body_string + formatWithIndent(current_template,
                 tag=tag,
                 style=style,
                 element_id=element_id,
+                attributes_string=attributes_string,
                 children_string=children_string,
             )
 

--- a/src/lqc/minify/minify_test_file.py
+++ b/src/lqc/minify/minify_test_file.py
@@ -183,6 +183,54 @@ def Enhance_ShortenIds(run_subject: RunSubject):
     yield renameIds
 
 
+def Enhance_DevOverlay(run_subject: RunSubject):
+
+    def addButtons(proposed_run_subject):
+        dev_overlay = {
+            "id": "lqc-dev-controls",
+            "tag": "div",
+            "children": [
+                {
+                    "id": "simpleRecreate",
+                    "tag": "button",
+                    "attributes": {"onclick": "simpleRecreate()",},
+                    "children": [{"tag": "<text>", "value": "simpleRecreate"}],
+                },
+                {
+                    "id": "checkForBug",
+                    "tag": "button",
+                    "attributes": {"onclick": "checkForBug()"},
+                    "children": [{"tag": "<text>", "value": "checkForBug"}],
+                },
+            ]
+        }
+
+        proposed_run_subject.base_styles.map["lqc-dev-controls"] = {    
+            "position": "fixed",
+            "top": "10px",
+            "right": "10px",
+            "background": "rgba(0, 0, 0, .75)",
+            "padding": "5px",
+            "z-index": "9999",
+            "display": "flex",
+            "flex-direction": "column",
+            "gap": "5px",
+        }
+
+        for btn_id in ["simpleRecreate", "checkForBug"]:
+            proposed_run_subject.base_styles.map[btn_id] = {
+                "background": "rgba(0, 0, 0, .75)",
+                "color": "rgba(255, 255, 255, 255)",
+                "padding": "6px 12px",
+                "border": "1px solid white",
+                "cursor": "pointer"
+            }
+
+        proposed_run_subject.html_tree.tree.append(dev_overlay)
+
+        return proposed_run_subject
+
+    yield addButtons;
 
 
 
@@ -197,6 +245,7 @@ class MinifyStepFactory():
         Enhance_MinHeightWidthPerElement,
         Enhance_BackgroundColorPerElement,
         Enhance_ShortenIds,
+        Enhance_DevOverlay,
     ]
 
     def __init__(self):


### PR DESCRIPTION
**Changes:**
- Changed the HTML creation script to allow different attributes when minifying. Currently only the "onclick" attribute will be allowed.
- Added a new step in the MinifyStepFactory that will add buttons to run both the `simpleRecreate()` and `checkForBug()` functions on click.

Currently the buttons will not show with some of the bugs due to the addition of a new div not allowing the bug to be reproduced.