### PR TITLE
Added a configuration option to prevent makeStyleChanges() from changing certain properties.

### DIFF
--- a/config/preset-firefox.config.json
+++ b/config/preset-firefox.config.json
@@ -9,7 +9,8 @@
 
     "style-weights": {
         "content-visibility": 0,
-        "writing-mode": 0,
-        "display": 100
-    }
+        "writing-mode": 0
+    },
+
+    "excluded-from-changes": ["display"]
 }

--- a/src/lqc/config/config.py
+++ b/src/lqc/config/config.py
@@ -27,6 +27,7 @@ class Config:
             # Class Initialization Code
             cls.__instance.style_weights = config.get("style-weights", {})
             cls.__instance.variants = config.get("variants", [])
+            cls.__instance.excluded_from_changes = config.get("excluded-from-changes", [])
             paths = config.get("paths", {})
             cls.__instance.path_bug_reports_dir = paths.get("bug-reports-directory", "./bug_reports")
             cls.__instance.path_tmp_files_dir = paths.get("tmp-files-directory", "./tmp_generated_files")
@@ -55,4 +56,8 @@ class Config:
 
     def getTmpFilesDirectory(self):
         return self.path_tmp_files_dir
+    
+    def isPropertyExcluded(self, property_name):
+        """Check if a CSS property should be excluded from being changed in style changes"""
+        return property_name in self.excluded_from_changes
     

--- a/src/lqc/model/style_map.py
+++ b/src/lqc/model/style_map.py
@@ -1,5 +1,6 @@
 INCLUDE_VALUE_IN_NAME = ["display"]
 
+from lqc.config.config import Config
 
 class StyleMap():
     map = {}
@@ -60,7 +61,9 @@ class StyleMap():
                 ret_string += 'if (' + elementId + ') {\n'
 
                 for (style_name, style_value) in elementStyles:
-                    ret_string += f'  {elementId}.style["{style_name}"] = "{style_value}";\n'
+                    # Skip properties that are configured to be excluded from being changed in style changes
+                    if not Config().isPropertyExcluded(style_name):
+                        ret_string += f'  {elementId}.style["{style_name}"] = "{style_value}";\n'
                 
                 ret_string += '}\n'
 


### PR DESCRIPTION
Using the `excluded-from-changes` property in the configuration, you can now specify CSS properties you wish to keep in the initial style, but wish to exclude in the changed styles.